### PR TITLE
Enable time-window based event display

### DIFF
--- a/PointCloudViewer.hpp
+++ b/PointCloudViewer.hpp
@@ -496,6 +496,24 @@ public:
         glBindBuffer(GL_ARRAY_BUFFER, 0);
     }
 
+    // Replace currently displayed points
+    void setPoints(const std::vector<Point>& new_points) {
+        std::lock_guard<std::mutex> lock(data_mutex_);
+        point_cloud_.clear();
+        point_colors_.clear();
+        point_cloud_.reserve(new_points.size() * 3);
+        point_colors_.reserve(new_points.size() * 3);
+        for (const auto& p : new_points) {
+            point_cloud_.push_back(p.x);
+            point_cloud_.push_back(p.y);
+            point_cloud_.push_back(p.z);
+            point_colors_.push_back(p.r / 255.0f);
+            point_colors_.push_back(p.g / 255.0f);
+            point_colors_.push_back(p.b / 255.0f);
+        }
+        data_updated_ = true;
+    }
+
 private:
     // Window parameters
     int width_, height_;

--- a/README.md
+++ b/README.md
@@ -67,14 +67,12 @@ Ensure you have the following installed on your system:
 > Note: Ensure build.sh has execution permissions. If not, make it executable: `$chmod +x build.sh`
 
 3. **Run the Application**
-4. **Execute the run script with a sample PCD file**
+4. **Execute the run script with a sample events CSV file**
 
 ```bash
-
-./run.sh data/lidar_kitti_sample.pcd
-
+./run.sh data/csv/events.csv 100
 ```
-> Note: Replace data/lidar_kitti_sample.pcd with the path to your own PCD file as needed.
+> Note: Replace `data/csv/events.csv` with the path to your CSV file and adjust the optional time window (in milliseconds) as needed. The viewer displays only the events within this sliding window.
 
 
 

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-./point_cloud_viewer "$1"
+# Usage: ./run.sh <csv_file> [window_ms]
+./point_cloud_viewer "$1" "$2"


### PR DESCRIPTION
## Summary
- stream events to the viewer grouped by a configurable time window
- allow specifying the time window from the command line
- update `run.sh` to pass the optional window argument
- document the new usage
- ensure only events within the selected window remain visible

## Testing
- `./build.sh` *(fails: GL/glew.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_684d858f4588832fa5d558d7f59457cd