### PR TITLE
Allow view rotation without cursor capture

### DIFF
--- a/PointCloudViewer.hpp
+++ b/PointCloudViewer.hpp
@@ -1105,9 +1105,14 @@ private:
         }
     }
 
-    // Mouse movement callback to respect cursor mode
+    // Mouse movement callback
     void mouse_callback(double xpos, double ypos) {
-        if (!cursor_captured_) return; // Do not process if cursor is not captured
+        // Allow rotation when the cursor is captured or while the left mouse
+        // button is being pressed. This makes it possible to adjust the
+        // viewing angle without toggling cursor capture.
+        if (!cursor_captured_ &&
+            glfwGetMouseButton(window_, GLFW_MOUSE_BUTTON_LEFT) != GLFW_PRESS)
+            return;
 
         if (first_mouse_) {
             last_x_ = static_cast<float>(xpos);

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Once the application is running smiler to this [demo](data/vid/CloudPeek_Viewer_
 
 
 ## 🖱 Mouse Controls
-- **Rotate Camera**: Click and drag the left mouse button to orbit around the target point.
+- **Rotate Camera**: Click and drag the left mouse button to orbit around the target point. The cursor doesn't need to be captured, but pressing `F1` allows unrestricted rotation across the entire window.
 - **Pan Camera**: Use the arrow keys or W, A, S, D to move the camera horizontally and vertically.
 - **Zoom**: Scroll the mouse wheel to zoom in and out.
 


### PR DESCRIPTION
## Summary
- enable camera rotation when dragging the left mouse button even if the cursor isn't captured
- clarify mouse control instructions in README

## Testing
- `bash build.sh` *(fails: GL/glew.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684d9407d0a4832f958474f1b82f9823